### PR TITLE
Minor bug fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,6 @@ app.put("/api/notes/updateNote/:id", async (req, res) => {
       Title: req.body.Title,
       Body: req.body.Body,
       Category: req.body.Category || "General",
-      Pinned: req.body.Pinned,
     };
 
     // Update the document


### PR DESCRIPTION
Removed the 'Pinned' field in the body as the front end no longer sends the 'Pinned' value in the PUT request when editing notes. 
This caused notes to have a null 'Pinned' value and messed with the chronological sorting of the notes sent to the front end.